### PR TITLE
WIP: Typescript definitions

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "url": "https://github.com/Lukasz-pluszczewski/perfect-immutable"
   },
   "main": "lib/perfect-immutable.js",
+  "types": "src/index.d.ts",
   "module": "lib/perfect-immutable.mjs",
   "jsnext:main": "lib/perfect-immutable.mjs",
   "scripts": {
@@ -48,6 +49,8 @@
     "sinon": "4.1.3"
   },
   "dependencies": {
-    "lodash": "4.17.4"
+    "@types/lodash": "4.14.93",
+    "lodash": "4.17.4",
+    "typescript": "2.6.2"
   }
 }

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,4 +1,23 @@
 declare module 'perfect-immutable' {
+    type ImmutableSetReturnFromPathString<V> = {
+        [x: string]: V
+    };
+    type ImmutableSetReturnFromPathObject<P> = {
+        [K in keyof P]: P[K];
+    }
+    interface ImmutableSetTransformFunction<T> {
+        (item: T): T
+    }
+
+    interface ImmutableSet {
+        <T>(target: T[], path: number, value: T, setFunction?: boolean): T[]
+        <T>(target: T[], path: number, value: ImmutableSetTransformFunction<T>, setFunction?: boolean): T[]
+
+        <T, V>(target: T, path: string, value: V, setFunction?: boolean): T & ImmutableSetReturnFromPathString<V>
+        <T, V>(target: T, path: string, value: ImmutableSetTransformFunction<T, V>, setFunction?: boolean): T & ImmutableSetReturnFromPathString<V>
+
+        <T, P>(target: T, path: P, value?: any, setFunction?: boolean): T & ImmutableSetReturnFromPathObject<P>
+    }
     interface ImmutableSplice {
         <T>(arr: T[], start: number, deleteCount: number, ...items: T[]): T[];
     }
@@ -25,6 +44,7 @@ declare module 'perfect-immutable' {
         <T>(obj: T, key: keyof T): Partial<T>;
     }
 
+    export const set: ImmutableSet;
     export const splice: ImmutableSplice;
     export const pop: ImmutablePop;
     export const push: ImmutablePush;

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,0 +1,36 @@
+declare module 'perfect-immutable' {
+    interface ImmutableSplice {
+        <T>(arr: T[], start: number, deleteCount: number, ...items: T[]): T[];
+    }
+    interface ImmutablePush {
+        <T>(arr: T[], newEntries: T[]): T[];
+    }
+    interface ImmutablePop {
+        <T>(arr: T[]): T[];
+    }
+    interface ImmutableShift {
+        <T>(arr: T[]): T[];
+    }
+    interface ImmutableUnshift {
+        <T>(arr: T[]): T[];
+    }
+    interface ImmutableSort {
+        <T>(arr: T[], compareFunction?: (a: T, b: T) => number): T[]
+    }
+    interface ImmutableReverse {
+        <T>(arr: T[]): T[];
+    }
+    interface ImmutableDelete {
+        <T>(arr: T[], index: number): T[];
+        <T>(obj: T, key: keyof T): Partial<T>;
+    }
+
+    export const splice: ImmutableSplice;
+    export const pop: ImmutablePop;
+    export const push: ImmutablePush;
+    export const immutableDelete: ImmutableDelete;
+    export const shift: ImmutableShift;
+    export const unshift: ImmutableUnshift;
+    export const sort: ImmutableSort;
+    export const reverse: ImmutableReverse;
+}


### PR DESCRIPTION
`set` function needs improvement. I'm not even sure it is possible to make it in typescript definition files.

Problem:
The `path` parameter might be a string, which contains of keys, separated with dot. We'd need to define n-level nesting (Where `n = numberOfDots + 1`) in `ImmutableSetReturnFromPathString` type somehow. Perhaps it would be a good idea to implement this method in typescript itself, and - if needed - slightly modify it, in order for it to be more "typed-way". wdyt?

Another story is: what if a user wants (for `GodKnowsWhy` reason), to have resulting object with key, that contains a dot e.g.
```
{
  foo: {
    bar: {
      'baz.zar': 'a value',
    }
  }
}
```
Is there a way to do that using `set` method?